### PR TITLE
i1018: Strip quotes and whitespace on username input

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -11,7 +11,7 @@ get_pass <- function(prompt) {
 }
 
 read_line <- function(prompt) {
-  readline(prompt = prompt) # nocov
+  clean_input_text(readline(prompt = prompt)) # nocov
 }
 
 ## We'll need this when connecting to localhost.  It should be the
@@ -38,4 +38,9 @@ encode_path <- function(x) {
 
 decode_path <- function(x) {
   gsub(":", "/", x, fixed = TRUE)
+}
+
+clean_input_text <- function(x) {
+  re <- "(^\\s*[\"']?|[\"']?\\s*$)"
+  gsub(re, "", x, perl = TRUE)
 }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -20,3 +20,17 @@ test_that("path encoding", {
   expect_equal(decode_path(c("foo:bar", "foo:bar:baz")),
                c("foo/bar", "foo/bar/baz"))
 })
+
+test_that("clean input text", {
+  ## For VIMC-1018
+  expect_equal(clean_input_text('"foo"'), "foo") # strip quotes
+  expect_equal(clean_input_text('  foo'), "foo") # strip leading whitespace
+  expect_equal(clean_input_text('foo  '), "foo") # strip trailing whitespace
+  expect_equal(clean_input_text(' foo '), "foo") # strip all whitespace
+  expect_equal(clean_input_text(' "foo" '), "foo") # strip all whitespace/quotes
+  expect_equal(clean_input_text(" 'foo' "), "foo") # strip all whitespace/quotes
+  ## But allow use of quotes to preserve whitespace
+  expect_equal(clean_input_text(' " foo " '), " foo ")
+  expect_equal(clean_input_text(" ' foo ' "), " foo ")
+  expect_equal(clean_input_text("f oo"), "f oo")
+})


### PR DESCRIPTION
To test this interactively, try

```r
get_input(NULL, "username2", FALSE)
```

and see what happens to quotes and leading/trailing whitespace