### PR TITLE
I1754 - add extra class to montagu remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: montagu
 Title: Interface with 'montagu'
-Version: 0.1.6
+Version: 0.1.7
 Description: R client for montagu
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/R/auth.R
+++ b/R/auth.R
@@ -94,9 +94,12 @@ montagu_set_default_location <- function(location) {
   montagu$default <- location
 }
 
+## this is going to change several times potentially.
 montagu_location <- function(location = NULL) {
   structure(location %||% montagu$default,
-            class = c("montagu_server", "orderly_api_server"))
+            class = c("montagu_server",
+                      "orderly_api_server",
+                      "orderly_remote_location"))
 }
 
 montagu_GET <- function(...) {

--- a/R/auth.R
+++ b/R/auth.R
@@ -95,7 +95,8 @@ montagu_set_default_location <- function(location) {
 }
 
 montagu_location <- function(location = NULL) {
-  location %||% montagu$default
+  structure(location %||% montagu$default,
+            class = c("montagu_server", "orderly_api_server"))
 }
 
 montagu_GET <- function(...) {


### PR DESCRIPTION
This is required to support changes in orderly itself.  The change here is fairly simple but will probably be done again in the future once there non montagu orderly api servers