### PR TITLE
i1772 - support for basic http auth

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^Makefile$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,4 +12,5 @@ Imports:
     openssl,
     progress
 Suggests:
-    testthat
+    testthat,
+    withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,9 @@
 Package: montagu
 Title: Interface with 'montagu'
-Version: 0.1.7
-Description: R client for montagu
+Version: 0.1.8
+Description: Client for interacting with the montagu APIs; both the
+  reporing API (for remote access to orderly) and the contribution API
+  are covered.  This package is part of montagu.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Author: Rich FitzJohn
@@ -9,6 +11,7 @@ Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Imports:
     getPass,
     httr,
+    jsonlite,
     openssl,
     progress
 Suggests:

--- a/R/auth.R
+++ b/R/auth.R
@@ -102,11 +102,13 @@ montagu_reauthorise <- function(location) {
 }
 
 montagu_set_default_location <- function(location) {
+  prev <- montagu$default
   if (!(location %in% names(montagu$hosts))) {
     stop(sprintf("Unknown montagu location '%s' - must be one of %s",
                  location, paste(names(montagu$hosts), collapse = ", ")))
   }
   montagu$default <- location
+  invisible(prev)
 }
 
 ## this is going to change several times potentially.

--- a/R/auth.R
+++ b/R/auth.R
@@ -1,13 +1,16 @@
 ## Montagu options:
 montagu <- new.env(parent = emptyenv())
 
-montagu_add_location <- function(name, hostname, port, verbose = FALSE,
+montagu_add_location <- function(name, hostname, port,
+                                 basic = FALSE,
+                                 verbose = FALSE,
                                  overwrite = FALSE) {
   if (name %in% names(montagu$hosts) && !overwrite) {
     return()
   }
   assert_scalar_character(hostname)
   assert_scalar_integer(port)
+  assert_scalar_logical(basic)
 
   api_version <- 1L
 
@@ -25,6 +28,7 @@ montagu_add_location <- function(name, hostname, port, verbose = FALSE,
   montagu$hosts[[name]] <- list(
     hostname = hostname,
     port = port,
+    basic = basic,
     opts = opts,
     api_version = api_version,
     url = sprintf("https://%s:%d/api/v%d",
@@ -34,6 +38,7 @@ montagu_add_location <- function(name, hostname, port, verbose = FALSE,
     url_www = url_www)
 }
 
+## These might move into the orderly_config.yml for montagu-reports
 montagu_add_location_defaults <- function() {
   montagu$hosts <- list()
   montagu_add_location("production", "montagu.vaccineimpact.org", 443L)
@@ -42,10 +47,10 @@ montagu_add_location_defaults <- function() {
   montagu_set_default_location("science")
 }
 
-montagu_credentials <- function(username, password) {
-  username <- get_input(username, "username", FALSE)
-  password <- get_input(password, "password", TRUE)
-  openssl::base64_encode(sprintf("%s:%s", username, password))
+montagu_credentials <- function(username, password, location) {
+  username <- get_input(username, "username", FALSE, location)
+  password <- get_input(password, "password", TRUE, location)
+  list(username = username, password = password)
 }
 
 montagu_authorise <- function(username = NULL, password = NULL,
@@ -58,17 +63,27 @@ montagu_authorise <- function(username = NULL, password = NULL,
   if (is.null(dat$token) || refresh) {
     message(sprintf("Authorising with montagu '%s' (https://%s:%s)",
                     location, dat$hostname, dat$port))
-    auth <- montagu_credentials(username, password)
-    h <- httr::add_headers("Authorization" = paste("Basic", auth))
+    auth <- montagu_credentials(username, password, location)
 
-    r <- httr::POST(paste0(dat$url, "/authenticate/"),
-                    h, dat$opts,
-                    body = list("grant_type" = "client_credentials"),
-                    encode = "form")
-    httr::stop_for_status(r)
-    t <- from_json(httr::content(r, "text", encoding = "UTF-8"))
-    dat$token <- httr::add_headers(
-      "Authorization" = paste("Bearer", t$access_token))
+    if (dat$basic) {
+      basic_auth <- httr::authenticate(auth$username, auth$password)
+      r <- httr::GET(dat$url_reports, basic_auth)
+      httr::stop_for_status(r)
+      dat$token <- basic_auth
+    } else {
+      auth_str <- openssl::base64_encode(sprintf("Basic %s:%s",
+                                                 auth$username, auth$password))
+      headers <- httr::add_headers("Authorization" = auth_str)
+
+      r <- httr::POST(paste0(dat$url, "/authenticate/"),
+                      headers, dat$opts,
+                      body = list("grant_type" = "client_credentials"),
+                      encode = "form")
+      httr::stop_for_status(r)
+      t <- from_json(httr::content(r, "text", encoding = "UTF-8"))
+      dat$token <- httr::add_headers(
+        "Authorization" = paste("Bearer", t$access_token))
+    }
     ## Retain the username and password in case we reauthorise
     dat$username <- username
     dat$password <- password

--- a/R/auth.R
+++ b/R/auth.R
@@ -71,9 +71,9 @@ montagu_authorise <- function(username = NULL, password = NULL,
       httr::stop_for_status(r)
       dat$token <- basic_auth
     } else {
-      auth_str <- openssl::base64_encode(sprintf("Basic %s:%s",
-                                                 auth$username, auth$password))
-      headers <- httr::add_headers("Authorization" = auth_str)
+      auth_str <- openssl::base64_encode(sprintf(
+        "%s:%s", auth$username, auth$password))
+      headers <- httr::add_headers("Authorization" = paste("Basic", auth_str))
 
       r <- httr::POST(paste0(dat$url, "/authenticate/"),
                       headers, dat$opts,

--- a/R/auth.R
+++ b/R/auth.R
@@ -61,7 +61,7 @@ montagu_authorise <- function(username = NULL, password = NULL,
     stop(sprintf("Unknown location '%s'", location))
   }
   if (is.null(dat$token) || refresh) {
-    message(sprintf("Authorising with montagu '%s' (https://%s:%s)",
+    message(sprintf("Authorising with server '%s' (https://%s:%s)",
                     location, dat$hostname, dat$port))
     auth <- montagu_credentials(username, password, location)
 

--- a/R/auth.R
+++ b/R/auth.R
@@ -193,16 +193,26 @@ montagu_dest <- function(dest, accept, progress) {
   }
 }
 
-get_input <- function(value, name, secret) {
+
+get_input <- function(value, name, secret, location) {
   if (is.null(value)) {
     read <- if (secret) get_pass else read_line
-    value <- getOption(paste0("montagu.", name),
-                       read(sprintf("Enter montagu %s: ", name)))
+    key <- c(sprintf("montagu.%s.%s", location, name),
+             sprintf("montagu.%s", name))
+    value <- get_option_cascade(key,
+                                read(sprintf("Enter montagu %s: ", name)))
   }
   assert_scalar_character(value, name)
   value
 }
 
-get_default <- function(value, name, default) {
-  value %||% getOption(paste0("montagu.", name), default)
+
+get_option_cascade <- function(x, default) {
+  for (el in x) {
+    v <- getOption(el)
+    if (!is.null(v)) {
+      return(v)
+    }
+  }
+  default
 }

--- a/R/reports.R
+++ b/R/reports.R
@@ -207,7 +207,7 @@ montagu_reports_run <- function(name, parameters = NULL, ref = NULL,
                  montagu$hosts[[location]]$url_www, name, ans$version)
   if (open) {
     message("Opening report in browser (you may need to log in)")
-    browseURL(url)
+    utils::browseURL(url)
   }
   list(name = name,
        id = ans$version,

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -34,3 +34,31 @@ test_that("clean input text", {
   expect_equal(clean_input_text(" ' foo ' "), " foo ")
   expect_equal(clean_input_text("f oo"), "f oo")
 })
+
+
+test_that("get_option_cacade uses correct priority", {
+  skip_if_not_installed("withr")
+
+  expect_equal(
+    withr::with_options(list(a = 1, b = 2), get_option_cascade(c("a", "b"), 3)),
+    1)
+  expect_equal(
+    withr::with_options(list(b = 2), get_option_cascade(c("a", "b"), 3)),
+    2)
+  expect_equal(
+    withr::with_options(list(), get_option_cascade(c("a", "b"), 3)),
+    3)
+})
+
+
+test_that("get_input follows convention", {
+  skip_if_not_installed("withr")
+
+  withr::with_options(
+    list(montagu.server.key = "special",
+         montagu.key = "general"),
+    expect_equal(get_input(NULL, "key", FALSE, "server"), "special"))
+  withr::with_options(
+    list(montagu.key = "general"),
+    expect_equal(get_input(NULL, "key", FALSE, "server"), "general"))
+})


### PR DESCRIPTION
This is the first half of this work only - the other is coming in on the orderly repo (but depends on this one).

- `montagu_add_location` gains a `basic` argument for indicating using HTTP basic auth (rather than the token issuing system we use for montagu)
- the default option picks up a tree structure (preferring `montagu.science.password` over `montagu.password`) but retains backward compatiblity
- basic http authentication using httr's `authenticate` (this part is actually not hard)

There are  a few minor QA tweaks scattered through as well