### PR TITLE
i2517: Better behaviour with report timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: packages
 
 r_github_packages:
   - vimc/orderly
-  - vimc/orderly.server
+  - vimc/orderly.server@i2517
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 cache: packages
 
 r_github_packages:
-  - vimc/orderly
+  - vimc/orderly@i2517
   - vimc/orderly.server@i2517
 
 addons:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
 Suggests:
     knitr,
     orderly (>= 0.5.17),
-    orderly.server (>= 0.1.1),
+    orderly.server (>= 0.1.2),
     rmarkdown,
     sys,
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: montagu
 Title: Interface with 'montagu'
-Version: 0.3.1
+Version: 0.3.2
 Description: Client for interacting with the montagu APIs; both the
   reporing API (for remote access to orderly) and the contribution API
   are covered.  This package is part of montagu.
@@ -21,7 +21,7 @@ Imports:
     storr
 Suggests:
     knitr,
-    orderly (>= 0.5.14),
+    orderly (>= 0.5.17),
     orderly.server (>= 0.1.1),
     rmarkdown,
     sys,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Error predictably when a report is killed by the remote server due to a timeout, and allow setting of this timeout (VIMC-2517)
+
 ## 0.3.1
 
 * Add support for models endpoints (VIMC-2545)

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -51,7 +51,7 @@ R6_montagu_orderly_remote <- R6::R6Class(
     },
 
     run = function(name, parameters = NULL, ref = NULL,
-                   timeout = 3600, poll = 1, progress = TRUE,
+                   timeout = NULL, wait = 1000, poll = 1, progress = TRUE,
                    stop_on_error = TRUE, open = FALSE) {
       montagu_reports_run(name, parameters = parameters, ref = ref,
                           timeout = timeout, poll = poll, progress = progress,

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -54,8 +54,10 @@ R6_montagu_orderly_remote <- R6::R6Class(
                    timeout = NULL, wait = 1000, poll = 1, progress = TRUE,
                    stop_on_error = TRUE, open = FALSE) {
       montagu_reports_run(name, parameters = parameters, ref = ref,
-                          timeout = timeout, poll = poll, progress = progress,
-                          stop_on_error = stop_on_error, open = open,
-                          location = self$location)
+                          timeout = timeout, poll = poll, wait = wait,
+                          progress = progress,
+                          stop_on_error = stop_on_error,
+                          stop_on_timeout = stop_on_timeout,
+                          open = open, location = self$location)
     }
   ))

--- a/R/reports.R
+++ b/R/reports.R
@@ -203,17 +203,18 @@ montagu_reports_data <- function(hash, csv = FALSE, dest = NULL,
 ##'   in progress.  This has an effect only when \code{progress} is
 ##'   \code{TRUE}.
 ##'
-##' @param wait Logical, indicating if we should wait for the report
-##'   to complete
+##' @param wait Integer value indicating time to wait on the client
+##'   side for the report to run.  If \code{0} (or less) we do not
+##'   wait.  If you provide a timeout you should make wait at least
+##'   the timeout value.
 montagu_reports_run <- function(name, parameters = NULL, ref = NULL,
                                 update = TRUE,
-                                timeout = 3600, poll = 0.5,
+                                timeout = NULL, wait = 3600, poll = 0.5,
                                 open = FALSE,
                                 stop_on_error = FALSE,
                                 stop_on_timeout = TRUE,
                                 progress = TRUE,
-                                location = NULL, output = TRUE,
-                                wait = TRUE) {
+                                location = NULL, output = TRUE) {
   location <- montagu_location(location)
   if (!is.null(parameters)) {
     stop("parameters not yet supported")
@@ -226,6 +227,10 @@ montagu_reports_run <- function(name, parameters = NULL, ref = NULL,
   if (!update) {
     query$update <- "false"
   }
+  if (!is.null(timeout)) {
+    assert_scalar_integer(timeout)
+    query$timeout <- as.character(timeout)
+  }
   if (length(query) == 0L) {
     query <- NULL
   }
@@ -235,8 +240,8 @@ montagu_reports_run <- function(name, parameters = NULL, ref = NULL,
   res$location <- location
   class(res) <- "montagu_report_instance"
 
-  if (wait) {
-    montagu_reports_wait(res, timeout = timeout, poll = poll,
+  if (wait > 0) {
+    montagu_reports_wait(res, timeout = wait, poll = poll,
                          open = open,
                          stop_on_error = stop_on_error,
                          stop_on_timeout = stop_on_timeout,

--- a/R/reports.R
+++ b/R/reports.R
@@ -264,7 +264,8 @@ montagu_reports_wait <- function(obj, timeout = 3600, poll = 0.5,
   key <- obj$key
   location <- obj$location
 
-  t_stop <- Sys.time() + timeout
+  t_start <- Sys.time()
+  t_stop <- t_start + timeout
   message(sprintf("running report '%s' as '%s'", name, key))
   fmt <- sprintf("[:spin] (%s) :elapsed :status", key)
   prev_output <- list(stderr = NULL, stdout = NULL)
@@ -316,6 +317,9 @@ montagu_reports_wait <- function(obj, timeout = 3600, poll = 0.5,
 
     if (state %in% c("queued", "running")) {
       Sys.sleep(if (state == "queued") max(poll, 1) else poll)
+    } else if (state == "killed") {
+      stop(sprintf("job killed by remote server after %d secs",
+                   round(as.numeric(Sys.time() - t_start, "secs"))))
     } else {
       break
     }

--- a/man/montagu_reports.Rd
+++ b/man/montagu_reports.Rd
@@ -55,7 +55,7 @@ montagu_reports_data(hash, csv = FALSE, dest = NULL, progress = TRUE,
   location = NULL)
 
 montagu_reports_run(name, parameters = NULL, ref = NULL,
-  update = TRUE, timeout = NULL, wait = 3600, poll = 0.5,
+  update = TRUE, timeout = NULL, wait = Inf, poll = 0.5,
   open = FALSE, stop_on_error = FALSE, stop_on_timeout = TRUE,
   progress = TRUE, location = NULL, output = TRUE)
 
@@ -101,7 +101,9 @@ this is often not desired.}
 
 \item{update}{I can't remember?}
 
-\item{timeout}{Time to give up on running report}
+\item{timeout}{Time to give up on running report; this is set on
+the \emph{server}.  After \code{timeout} seconds, the server
+will kill the running report.}
 
 \item{wait}{Integer value indicating time to wait on the client
 side for the report to run.  If \code{0} (or less) we do not

--- a/man/montagu_reports.Rd
+++ b/man/montagu_reports.Rd
@@ -55,9 +55,9 @@ montagu_reports_data(hash, csv = FALSE, dest = NULL, progress = TRUE,
   location = NULL)
 
 montagu_reports_run(name, parameters = NULL, ref = NULL,
-  update = TRUE, timeout = 3600, poll = 0.5, open = FALSE,
-  stop_on_error = FALSE, stop_on_timeout = TRUE, progress = TRUE,
-  location = NULL, output = TRUE, wait = TRUE)
+  update = TRUE, timeout = NULL, wait = 3600, poll = 0.5,
+  open = FALSE, stop_on_error = FALSE, stop_on_timeout = TRUE,
+  progress = TRUE, location = NULL, output = TRUE)
 
 montagu_reports_wait(obj, timeout = 3600, poll = 0.5, open = FALSE,
   stop_on_error = FALSE, stop_on_timeout = TRUE, progress = TRUE,
@@ -103,6 +103,11 @@ this is often not desired.}
 
 \item{timeout}{Time to give up on running report}
 
+\item{wait}{Integer value indicating time to wait on the client
+side for the report to run.  If \code{0} (or less) we do not
+wait.  If you provide a timeout you should make wait at least
+the timeout value.}
+
 \item{poll}{Time to poll for update}
 
 \item{open}{Open the report in a browser on completion?}
@@ -114,9 +119,6 @@ this is often not desired.}
 \item{output}{Show output from running the report.  This is a work
 in progress.  This has an effect only when \code{progress} is
 \code{TRUE}.}
-
-\item{wait}{Logical, indicating if we should wait for the report
-to complete}
 
 \item{obj}{A \code{montagu_reports_instance} object, as created by
 \code{montagu_reports_run}.}

--- a/tests/testthat/helper-montagu.R
+++ b/tests/testthat/helper-montagu.R
@@ -28,10 +28,8 @@ montagu_test_server <- function() {
 }
 
 
-orderly_test_server <- function() {
+orderly_test_server <- function(name = "interactive", port = 8321) {
   testthat::skip_on_travis()
-  name <- "interactive"
-  port <- 8321
   path <- orderly:::prepare_orderly_example(name)
   server <- orderly.server::orderly_server_background(path, port)
   server$start()

--- a/tests/testthat/test-reports-run.R
+++ b/tests/testthat/test-reports-run.R
@@ -47,3 +47,23 @@ test_that("run: error", {
   ## And check that it turns up _somewhere_
   expect_match(ans$output$stderr, cmp$message, fixed = TRUE, all = FALSE)
 })
+
+
+test_that("set timeout", {
+  server <- orderly_test_server("interactive")
+  remote <- montagu_server("testing", "localhost", server$port, orderly = TRUE)
+
+  p <- file.path(server$path, "src", "count", "parameters.json")
+  writeLines(jsonlite::toJSON(list(time = 2, poll = 0.1), auto_unbox = TRUE),
+             p)
+
+  ans <- montagu_reports_run("count", location = remote, timeout = 1,
+                             progress = FALSE)
+  expect_equal(ans$status, "killed")
+  expect_null(ans$url)
+
+  expect_error(
+    montagu_reports_run("count", location = remote, timeout = 1,
+                        progress = FALSE, stop_on_error = TRUE),
+    "job killed by remote server after")
+})


### PR DESCRIPTION
This fixes a couple of poor behaviours with report timeouts:

* If the report is killed we don't try to open it and we throw an error if requested
* The `timeout` parameter is forwarded on to the server
* New `wait` parameter, which is the client-side time to wait

See also: https://github.com/vimc/orderly/pull/82 and https://github.com/vimc/orderly.server/pull/10

**NOTE**: The `orderly.server` and `orderly` PRs should be merged first, and the `.travis.yml` for this repo should be reverted prior to merging this PR

