### PR TITLE
i2816L Pass through the stop_on_timeout argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: montagu
 Title: Interface with 'montagu'
-Version: 0.3.7
+Version: 0.3.8
 Description: Client for interacting with the montagu APIs; both the
   reporing API (for remote access to orderly) and the contribution API
   are covered.  This package is part of montagu.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.3.8
+
+* Fix passing through the `stop_on_timeout` parameter (VIMC-2816)
+
 ## 0.3.7
 
 * Review support of demographic endpoints (VIMC-2723)

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -52,7 +52,8 @@ R6_montagu_orderly_remote <- R6::R6Class(
 
     run = function(name, parameters = NULL, ref = NULL,
                    timeout = NULL, wait = 1000, poll = 1, progress = TRUE,
-                   stop_on_error = TRUE, open = FALSE) {
+                   stop_on_error = TRUE, stop_on_timeout = TRUE,
+                   open = FALSE) {
       montagu_reports_run(name, parameters = parameters, ref = ref,
                           timeout = timeout, poll = poll, wait = wait,
                           progress = progress,


### PR DESCRIPTION
The runner is currently broken for the orderly+montagu versions on the drat