### PR TITLE
VIMC-3000

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,1 +1,2 @@
 global_servers <- new.env(parent = emptyenv())
+


### PR DESCRIPTION
Find out why travis builds are failing + fix them.

This is the error from PR#31

```
[09:05:01][Step 2/4] * checking tests ...
[09:05:07][Step 2/4]  ERROR
[09:05:07][Step 2/4]   Running ‘testthat.R’
[09:05:07][Step 2/4] Running the tests in ‘tests/testthat.R’ failed.
[09:05:07][Step 2/4] Last 13 lines of output:
[09:05:07][Step 2/4]   ══ testthat results  ═══════════════════════════════════════════════════════════
[09:05:07][Step 2/4]   OK: 40 SKIPPED: 5 FAILED: 147
[09:05:07][Step 2/4]   1. Failure: Burden estimate sets info - incorrect group (@test-burden.R#22) 
[09:05:07][Step 2/4]   2. Failure: Burden estimate sets - incorrect touchstone (@test-burden.R#29) 
[09:05:07][Step 2/4]   3. Failure: Burden estimate sets - incorrect scenario (@test-burden.R#36) 
[09:05:07][Step 2/4]   4. Failure: Burden estimate set info - incorrect group (@test-burden.R#46) 
[09:05:07][Step 2/4]   5. Failure: Burden estimate set info - incorrect touchstone (@test-burden.R#53) 
[09:05:07][Step 2/4]   6. Failure: Burden estimate set info - incorrect scenario (@test-burden.R#60) 
[09:05:07][Step 2/4]   7. Failure: Burden estimate set info - incorrect estimate set id (@test-burden.R#67) 
[09:05:07][Step 2/4]   8. Failure: Burden estimate set data - incorrect group (@test-burden.R#76) 
[09:05:07][Step 2/4]   9. Failure: Burden estimate set data - incorrect touchstone (@test-burden.R#83) 
```