### PR TITLE
VIMC-3029: update auth to work with orderlyweb

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: montagu
 Title: Interface with 'montagu'
-Version: 0.3.8
+Version: 0.4.0
 Description: Client for interacting with the montagu APIs; both the
   reporing API (for remote access to orderly) and the contribution API
   are covered.  This package is part of montagu.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+* Support for the new montagu/OrderlyWeb authentication flow, required for use with montagu >= 2.0.0 (VIMC-3029)
+
 ## 0.3.9
 
 * More support for touchstone endpoints (VIMC-2722)

--- a/tests/testthat/test-demographics.R
+++ b/tests/testthat/test-demographics.R
@@ -95,7 +95,7 @@ test_that("demographic list is cached within session", {
   expect_identical(d, location$cache$get(touchstone_id, "demographics_list"))
   ## Remove the token so that we can't possibly make a call; if we do
   ## make a call after this we'll get a message
-  location$token <- NULL
+  location$token_api <- NULL
   expect_message(
     d2 <- montagu_demographics_list(touchstone_id, location = location),
     NA)

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -20,6 +20,6 @@ test_that("download correct model id", {
 test_that("download incorrect model id", {
   location <- montagu_test_server_user()
   expect_error(montagu_model(model_id = "YFICZZZ", location = location),
-               "Unknown model_id with id 'YFICZZZ'",
+               "Unknown model with id 'YFICZZZ'",
                class = "montagu_api_error")
 })


### PR DESCRIPTION
This PR implements the two-step montagu/orderly web auth.

There is one unrelated change that fixes the text reported back in an error