### PR TITLE
Fix error msg / update for different burden outcome API return type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: montagu
 Title: Interface with 'montagu'
-Version: 0.5.0
+Version: 0.5.1
 Description: Client for interacting with the montagu APIs; both the
   reporing API (for remote access to orderly) and the contribution API
   are covered.  This package is part of montagu.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 0.5.1
 
-* Update montagu_expectation_outcomes due to API change. (VIMC-3102, VIMC
+* Update montagu_expectation_outcomes due to API change. (VIMC-3102, VIMC-3081)
 
 ## 0.5.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Update montagu_expectation_outcomes due to API change. (VIMC-3102, VIMC
+
 ## 0.5.0
 
 * Support for login using GitHub for OrderlyWeb (VIMC-3051)

--- a/R/responsibilities.R
+++ b/R/responsibilities.R
@@ -317,7 +317,7 @@ montagu_expectation_outcomes <- function(modelling_group_id, touchstone_id,
 
   unlist(lapply(helper_get_expectation(modelling_group_id, touchstone_id,
                          expectation_id, location)$expectation$outcomes, 
-         "[[", "name"))
+         "[[", "code"))
 }
 
 ##' Different scenarios may have different expectations. For example, for

--- a/R/responsibilities.R
+++ b/R/responsibilities.R
@@ -315,8 +315,9 @@ montagu_expectation_countries <- function(modelling_group_id, touchstone_id,
 montagu_expectation_outcomes <- function(modelling_group_id, touchstone_id,
                                          expectation_id, location = NULL) {
 
-  helper_get_expectation(modelling_group_id, touchstone_id,
-                         expectation_id, location)$expectation$outcomes
+  unlist(lapply(helper_get_expectation(modelling_group_id, touchstone_id,
+                         expectation_id, location)$expectation$outcomes, 
+         "[[", "name"))
 }
 
 ##' Different scenarios may have different expectations. For example, for

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Note that the package name is `montagu` but this repo is [`vimc/montagu-r`](http
 - [x] `/v1/modelling-groups/` (GET)
 - [ ] `/v1/modelling-groups/` (POST)
 - [x] `/v1/modelling-groups/:group-id/` (GET)
-- [ ] `/v1/modelling-groups/:group-id/actions/associate-memeber/` (POST)
+- [ ] `/v1/modelling-groups/:group-id/actions/associate-member/` (POST)
 - [x] `/v1/modelling-groups/:group-id/expectations/:touchstone-id/:expectation-id/` (GET)
 - [x] `/v1/modelling-groups/:group-id/model-run-parameters/:touchstone-id/` (GET)
 - [x] `/v1/modelling-groups/:group-id/model-run-parameters/:touchstone-id/` (POST)

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -20,6 +20,6 @@ test_that("download correct model id", {
 test_that("download incorrect model id", {
   location <- montagu_test_server_user()
   expect_error(montagu_model(model_id = "YFICZZZ", location = location),
-               "Unknown model with id 'YFICZZZ'",
+               "Unknown model_id with id 'YFICZZZ'",
                class = "montagu_api_error")
 })

--- a/tests/testthat/test-models.R
+++ b/tests/testthat/test-models.R
@@ -20,6 +20,6 @@ test_that("download correct model id", {
 test_that("download incorrect model id", {
   location <- montagu_test_server_user()
   expect_error(montagu_model(model_id = "YFICZZZ", location = location),
-               "Unknown model_id with id 'YFICZZZ'",
+               "Unknown research-model-details with id 'YFICZZZ'",
                class = "montagu_api_error")
 })

--- a/vignettes_src/montagu_user_guide.Rmd
+++ b/vignettes_src/montagu_user_guide.Rmd
@@ -29,7 +29,7 @@ montagu::montagu_server_global_default_set(
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(error = FALSE, fig.path = "figure/montagu_user_guide-")
-options(montagu.username = "test.user@imperial.ac.uk",
+options(montagu.username = "test.admin@imperial.ac.uk",
         montagu.password = "password")
 montagu::montagu_server_global_default_set(
   montagu::montagu_server("science", "support.montagu.dide.ic.ac.uk", 11443))


### PR DESCRIPTION
The change in reponsibilities.R ensures backward compatability regarding this change...

https://github.com/vimc/montagu-api/commit/eab720c2d5104db05ecde76e5d1884662599234f#diff-fa961344d83b6c1b7772e01770646000

and the other change in test-models.R is just updated text in the error message from the API.